### PR TITLE
Check the PID before going on a wild goose chase

### DIFF
--- a/workaround-upstart-snafu
+++ b/workaround-upstart-snafu
@@ -32,7 +32,18 @@ class Workaround
   def initialize target_pid
     @target_pid = target_pid
 
+    quit_if_process_exists
     first_child
+  end
+  
+  def quit_if_process_exists
+    warning = "There is already a process running with the PID #{@target_pid}, try killing it?"
+    Process.kill(0, @target_pid)
+    puts(warning) & exit
+  rescue Errno::EPERM
+    puts(warning) & exit
+  rescue Errono::ESRCH
+    puts "No process with that PID currently running - attempting to obtain the PID."
   end
 
   def first_child


### PR DESCRIPTION
If the PID is already being used by a running process, this process becomes very hard to stop, so this checks the PID landscape first.
